### PR TITLE
Update op-node and op-geth to resolve 'payload is on v3 topic, but has non-zero blob gas used'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ volumes:
 
 services:
   execution-client:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.4
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.5
     env_file:
       - .env
       # select your network here:
@@ -26,7 +26,7 @@ services:
     entrypoint: /entrypoint.sh
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.2
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.2
     env_file:
       - .env
       # select your network here:


### PR DESCRIPTION
op-node & op-geth for Unichain node are on outdated versions. Pushing this so that blocks resume syncing, since my nodes returned 'payload is on v3 topic, but has non-zero blob gas used' errors.